### PR TITLE
ポート番号を3500に変更

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,7 +10,7 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 3500 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
rails sで起動した時のローカルサーバーのポート番号を3000→3500に変更

https://qiita.com/Orangina1050/items/9d816017217614bc3ce7