### PR TITLE
レスポンスのJSONをキャメルケースで返すように設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'rails', '~> 6.0.3', '>= 6.0.3.7'
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.7'
+# JSONをsnake_case <-> camelCaseで変換する Read more: https://github.com/vigetlabs/olive_branch
+gem "olive_branch"
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,10 +82,14 @@ GEM
     mini_portile2 (2.5.3)
     minitest (5.14.4)
     msgpack (1.4.2)
+    multi_json (1.15.0)
     nio4r (2.5.7)
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    olive_branch (4.0.0)
+      multi_json
+      rails (>= 4.0)
     pg (1.2.3)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -152,6 +156,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   listen (~> 3.2)
+  olive_branch
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rack-cors

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,9 @@ module ChatAppApi
     config.api_only = true
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+
+    # レスポンスのJSONをsnake_case -> camelCaseに変換する
+    # https://codethumbs.com/2020/07/19/how-to-make-your-rails-api-work-with-camelcase/
+    config.middleware.use OliveBranch::Middleware, inflection: 'camel'
   end
 end


### PR DESCRIPTION
## 目的
- レスポンスのJSONのキーをキャメルケースにして返却するようにするため

## 備考
- 下記を参考にJbuilderで試してみたがうまくいかなかった。
https://qiita.com/vochicong/items/d64f3b3d5a448a3b1f42#%E5%85%A8%E3%81%A6%E3%81%AEapi%E3%81%B8%E3%81%AE%E9%81%A9%E7%94%A8-1
- Olive Branchというgemを使うことにした。
- 参考
https://codethumbs.com/2020/07/19/how-to-make-your-rails-api-work-with-camelcase/